### PR TITLE
Stable page creation & deletion + Ability to load and create projects at boot.

### DIFF
--- a/src/com/jdngray77/htmldesigner/Launcher.kt
+++ b/src/com/jdngray77/htmldesigner/Launcher.kt
@@ -9,3 +9,10 @@ fun main() {
     Thread.setDefaultUncaughtExceptionHandler(ExceptionListener)
     Application.launch(Editor::class.java)
 }
+
+enum class ExitReasons {
+    NORMAL,
+    NO_PROJECT,
+    USER_REQUEST,
+    CRASH_GENERIC
+}

--- a/src/com/jdngray77/htmldesigner/MVC.kt
+++ b/src/com/jdngray77/htmldesigner/MVC.kt
@@ -240,7 +240,7 @@ class MVC (
 
     fun delete(projectFile: File) {
         if (projectFile.isDirectory &&
-            userConfirm("\"${projectFile.name} is not empty. \\n Are you sure you want to delete it's contents?\""))
+            userConfirm("${projectFile.name} is not empty. \n Are you sure you want to delete it's contents?"))
                 projectFile.listTree().map { delete(it) }
 
         Project.deleteFile(projectFile)

--- a/src/com/jdngray77/htmldesigner/MVC.kt
+++ b/src/com/jdngray77/htmldesigner/MVC.kt
@@ -2,10 +2,9 @@ package com.jdngray77.htmldesigner
 
 import com.jdngray77.htmldesigner.backend.*
 import com.jdngray77.htmldesigner.backend.data.Project
+import com.jdngray77.htmldesigner.backend.data.Project.Companion.projectFile
 import com.jdngray77.htmldesigner.frontend.DocumentEditor
 import com.jdngray77.htmldesigner.frontend.MainViewController
-import javafx.scene.control.Alert
-import javafx.scene.control.Alert.AlertType
 import javafx.scene.control.ButtonType
 import javafx.scene.control.Tab
 import javafx.scene.layout.BorderPane
@@ -91,6 +90,14 @@ class MVC (
      */
     fun findEditorFor(tab: Tab)  =
         openEditors.find { it.tab == tab }
+
+    /**
+     * Finds the editor for the given File
+     *
+     * @param file the file to find the editor for.
+     */
+    fun findEditorFor(file: File)  =
+        openEditors.find { it.file == file }
 
     /**
      * Creates and opens a new document editor for the
@@ -179,6 +186,22 @@ class MVC (
         findEditorFor(document)?.apply { switchToEditor(this) }
             ?: run { openDocument(document) }
 
+    fun validateEditors() {
+        // Find tabs that are not in [openEditors], and remove them.
+
+        MainView.dockEditors.tabs.removeAll(
+            MainView.dockEditors.tabs.filter { tab ->
+                openEditors.find { it.tab == tab } == null
+            }
+        )
+
+        // Check that remaining editors' files exist. Else, close the editor.
+        openEditors.filter {
+            !it.file.exists()
+        }.map {
+            it.requestClose()
+        }
+    }
 
     //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     //endregion                                                     Editors
@@ -220,12 +243,13 @@ class MVC (
             userConfirm("\"${projectFile.name} is not empty. \\n Are you sure you want to delete it's contents?\""))
                 projectFile.listTree().map { delete(it) }
 
+        Project.deleteFile(projectFile)
         if (projectFile.name.endsWith(".html")) {
-            findEditorFor(Project.loadDocument(projectFile))?.requestClose()
+            findEditorFor(projectFile)?.forceClose()
             EventNotifier.notifyEvent(EventType.PROJECT_PAGE_DELETED)
         }
 
-        Project.deleteFile(projectFile)
+        validateEditors()
     }
 
     /**

--- a/src/com/jdngray77/htmldesigner/MVC.kt
+++ b/src/com/jdngray77/htmldesigner/MVC.kt
@@ -4,6 +4,8 @@ import com.jdngray77.htmldesigner.backend.*
 import com.jdngray77.htmldesigner.backend.data.Project
 import com.jdngray77.htmldesigner.frontend.DocumentEditor
 import com.jdngray77.htmldesigner.frontend.MainViewController
+import javafx.scene.control.Alert
+import javafx.scene.control.Alert.AlertType
 import javafx.scene.control.ButtonType
 import javafx.scene.control.Tab
 import javafx.scene.layout.BorderPane
@@ -46,7 +48,7 @@ class MVC (
     }
 
     override fun notify(e: EventType) {
-        if (e == EventType.EDITOR_LOADED)
+        if (e == EventType.EDITOR_LOADED && Project.documents().isNotEmpty())
             openDocument(Project.loadDocument(Project.documents().first()))
     }
 
@@ -194,7 +196,6 @@ class MVC (
      */
     fun deleteTag(vararg tag: Element) {
         if (tag.isEmpty()) return
-
         if (!
             if (tag.size > 1)
                 userConfirm("Delete multiple tags? \n\n ${tag.joinToString { "\n" + it.tagName() }}")
@@ -212,6 +213,19 @@ class MVC (
             finishedModifying()
         }
         MainView.setAction("Deleted tag(s)")
+    }
+
+    fun delete(projectFile: File) {
+        if (projectFile.isDirectory &&
+            userConfirm("\"${projectFile.name} is not empty. \\n Are you sure you want to delete it's contents?\""))
+                projectFile.listTree().map { delete(it) }
+
+        if (projectFile.name.endsWith(".html")) {
+            findEditorFor(Project.loadDocument(projectFile))?.requestClose()
+            EventNotifier.notifyEvent(EventType.PROJECT_PAGE_DELETED)
+        }
+
+        Project.deleteFile(projectFile)
     }
 
     /**

--- a/src/com/jdngray77/htmldesigner/backend/EventNotifier.kt
+++ b/src/com/jdngray77/htmldesigner/backend/EventNotifier.kt
@@ -75,7 +75,7 @@ object EventNotifier {
             it.notify(e)
         }
 
-        log("Notified $e to ${tempList.size} Subscribers ($tempList)")
+        logStatus("Notified $e to ${tempList.size} Subscribers ($tempList)")
     }
 
 }

--- a/src/com/jdngray77/htmldesigner/backend/ExceptionListener.kt
+++ b/src/com/jdngray77/htmldesigner/backend/ExceptionListener.kt
@@ -2,13 +2,14 @@ package com.jdngray77.htmldesigner.backend
 
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvcIfAvail
 import java.lang.Thread.UncaughtExceptionHandler
+import java.security.PrivilegedActionException
 
 object ExceptionListener : UncaughtExceptionHandler{
     override fun uncaughtException(t: Thread?, e: Throwable?) {
         e?.let {
             mvcIfAvail()?.Project?.logError(e)
             e.printStackTrace()
-            WarnError(e)
+            NotifyOfError(if (e is PrivilegedActionException) e.exception else e)
         }
     }
 }

--- a/src/com/jdngray77/htmldesigner/backend/ExceptionListener.kt
+++ b/src/com/jdngray77/htmldesigner/backend/ExceptionListener.kt
@@ -9,7 +9,14 @@ object ExceptionListener : UncaughtExceptionHandler{
         e?.let {
             mvcIfAvail()?.Project?.logError(e)
             e.printStackTrace()
-            NotifyOfError(if (e is PrivilegedActionException) e.exception else e)
+            NotifyOfError(sanitizeException(e))
         }
     }
+
+    private fun sanitizeException(e: Throwable) =
+        if (e is PrivilegedActionException) e.exception else e.rootCause()
 }
+
+
+fun Throwable.rootCause() : Throwable =
+    cause?.let { it.rootCause() } ?: this

--- a/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
+++ b/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
@@ -2,7 +2,6 @@ package com.jdngray77.htmldesigner.backend
 
 import com.jdngray77.htmldesigner.frontend.Editor
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvcIfAvail
-import com.sun.javafx.scene.control.skin.TableViewSkin
 import com.sun.javafx.scene.control.skin.TreeTableViewSkin
 import javafx.fxml.FXMLLoader
 import javafx.scene.Parent
@@ -11,7 +10,7 @@ import javafx.scene.control.*
 import jfxtras.styles.jmetro.JMetro
 import jfxtras.styles.jmetro.Style
 import org.controlsfx.control.Notifications
-import org.controlsfx.control.PropertySheet.Item
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.awt.Toolkit
 import java.io.*
@@ -19,7 +18,6 @@ import java.nio.file.Files
 import java.util.function.Consumer
 import kotlin.reflect.KProperty
 import kotlin.reflect.KMutableProperty1
-import kotlin.reflect.full.declaredMembers
 
 /**
  * # Container for generic utility methods to aid you in doing whatever it is you do.
@@ -122,7 +120,7 @@ fun Element.saveToDisk(f: File) {
 //                                                        Logging
 //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
-fun WarnError(e: Throwable) {
+fun NotifyOfError(e: Throwable) {
     Notifications.create()
         .title("An error has occurred with the editor.")
         .text("${e::class.simpleName} \n ${
@@ -146,23 +144,20 @@ fun WarnError(e: Throwable) {
 }
 
 
-fun DeveloperWarning(string: String) {
-    UserWarning(string)
-}
-
-fun UserWarning(string: String) {
+fun logWarning(string: String) {
     System.err.println(string)
     mvcIfAvail()?.MainView?.setStatus(string)
 }
 
-fun log(string: String) = UserMessage(string)
 
-fun UserMessage(string: String) {
+fun logStatus(string: String) {
     mvcIfAvail()?.MainView?.setStatus(string)
     println(string)
 }
 
-
+fun AlertUser(message: String) {
+    Alert(Alert.AlertType.INFORMATION, message, ButtonType.OK).showAndWait()
+}
 
 
 
@@ -254,6 +249,10 @@ fun TreeTableColumn<*, *>.pack(table : TreeTableView<*>) {
     }
 }
 
+
+fun Document.open() {
+    mvcIfAvail()?.openDocument(this)
+}
 
 
 //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

--- a/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
+++ b/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
@@ -7,6 +7,8 @@ import javafx.fxml.FXMLLoader
 import javafx.scene.Parent
 import javafx.scene.Scene
 import javafx.scene.control.*
+import javafx.scene.input.Clipboard
+import javafx.scene.input.ClipboardContent
 import jfxtras.styles.jmetro.JMetro
 import jfxtras.styles.jmetro.Style
 import org.controlsfx.control.Notifications
@@ -252,6 +254,14 @@ fun TreeTableColumn<*, *>.pack(table : TreeTableView<*>) {
 
 fun Document.open() {
     mvcIfAvail()?.openDocument(this)
+}
+
+fun CopyToClipboard(string: String) {
+    Clipboard.getSystemClipboard().setContent(
+        ClipboardContent().apply {
+            putString(string)
+        }
+    )
 }
 
 

--- a/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
+++ b/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
@@ -123,7 +123,6 @@ fun Element.saveToDisk(f: File) {
 //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
 fun WarnError(e: Throwable) {
-
     Notifications.create()
         .title("An error has occurred with the editor.")
         .text("${e::class.simpleName} \n ${

--- a/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
+++ b/src/com/jdngray77/htmldesigner/backend/ScriptTools.kt
@@ -161,6 +161,10 @@ fun AlertUser(message: String) {
     Alert(Alert.AlertType.INFORMATION, message, ButtonType.OK).showAndWait()
 }
 
+fun AlertUserOfError(message: String) {
+    Alert(Alert.AlertType.ERROR, message, ButtonType.OK).showAndWait()
+}
+
 
 
 

--- a/src/com/jdngray77/htmldesigner/backend/data/Project.kt
+++ b/src/com/jdngray77/htmldesigner/backend/data/Project.kt
@@ -334,9 +334,10 @@ class Project(
         File(subPath(loc)).apply {
             createNewFile()
             doc.title(name)
+            saveDocument(doc, path)
         }
 
-        saveDocument(doc, loc)
+
 
         saveMeta()
 

--- a/src/com/jdngray77/htmldesigner/backend/data/Project.kt
+++ b/src/com/jdngray77/htmldesigner/backend/data/Project.kt
@@ -547,20 +547,26 @@ class Project(
         const val PROJECT_PATH_MEDIA: String = "MEDIA/"
 
 
-
+        /**
+         * Creates a new project at the specified location.
+         *
+         * @param path The path to the project directory.
+         */
+        fun create(path : String) = Project(File(path))
 
         /**
-         * Attempts to load a project from disk, if it exists.
+         * Loads a project from disk
          *
-         * If there is no project at the [path], then one is created.
+         * If the project meta file exists, load it, validate it, and return it.
          *
-         * @return the existing or new project.
-         * @throws InvalidClassException if a project exists, but was made by a different version of the editor and cannot be loaded.
+         * @param path The path to the project folder
+         * @return A Project object
          */
-        fun loadOrCreate(path: String): Project? {
+        fun load(path : String) : Project? {
             File("$path/$PROJECT_PATH_META").apply {
-                if (exists()) {
-                    return try {
+                if (!exists())
+                    throw NoSuchFileException(this, reason = "\n\nThere is no $PROJECT_PATH_META file in ${parentFile.name}. \nAre you sure this is the right folder?")
+                return try {
                         val proj = loadObjectFromDisk(this) as Project
                         proj.validate()
                         logStatus("Loaded Existing Project '${proj.locationOnDisk.name}'")
@@ -570,9 +576,7 @@ class Project(
                                 "To load this project, you need an editor that supports the following project version : \n\n${Project::class.hashCode()}\n\n" +
                                 "To find what editor version you need, visit \n\nhttps://github.com/jdngray77/HTMLDesigner/wiki/IDE-to-Project-Version-Map")
                         null
-                    }
-                }
-                return Project(File(path))
+                   }
             }
         }
 

--- a/src/com/jdngray77/htmldesigner/backend/data/Project.kt
+++ b/src/com/jdngray77/htmldesigner/backend/data/Project.kt
@@ -134,6 +134,9 @@ class Project(
     @Transient
     private lateinit var CACHE : HashMap<String, Any>
 
+    @Deprecated("This is for debug access only. Cache is internal to the project only.")
+    fun getCache() = CACHE
+
     init {
         checkPath()
         createSkeleton()
@@ -169,6 +172,18 @@ class Project(
 
         if (!this::CACHE.isInitialized)
             CACHE = HashMap()
+        else validateCache()
+    }
+
+    fun validateCache() {
+        val toRemove = ArrayList<String>()
+
+        CACHE.entries.forEach {
+            if (!File(it.key).exists())
+                toRemove.add(it.key)
+        }
+
+        toRemove.map { CACHE.remove(it) }
     }
 
 
@@ -427,8 +442,8 @@ class Project(
     }
 
     fun deleteFile(projectFile: File) {
-        CACHE.remove(projectFile.relativeToOrSelf(locationOnDisk).path)
         projectFile.delete()
+        validateCache()
     }
 
 

--- a/src/com/jdngray77/htmldesigner/backend/data/Project.kt
+++ b/src/com/jdngray77/htmldesigner/backend/data/Project.kt
@@ -143,8 +143,8 @@ class Project(
     init {
         checkPath()
         createSkeleton()
-        createDocument("index.html")
         validate()
+        createDocument("index.html")
         logStatus("Created new project '${locationOnDisk.name}'")
     }
 

--- a/src/com/jdngray77/htmldesigner/backend/html/dom/Tag.kt
+++ b/src/com/jdngray77/htmldesigner/backend/html/dom/Tag.kt
@@ -472,6 +472,7 @@ abstract class Tag : SerializableHTML {
                 .insertChildren(
                     0,
                     Element("h1")
+                        .id("PageTitle")
                         .appendText("Hello!")
                         .attr("style", "text-decoration: underline;"),
                     Element("hr"),

--- a/src/com/jdngray77/htmldesigner/backend/html/dom/Tags.kt
+++ b/src/com/jdngray77/htmldesigner/backend/html/dom/Tags.kt
@@ -1,6 +1,6 @@
 package com.jdngray77.htmldesigner.backend.html.dom
 
-import com.jdngray77.htmldesigner.backend.UserWarning
+import com.jdngray77.htmldesigner.backend.logWarning
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.safety.Safelist
@@ -298,7 +298,7 @@ class html(val title: String) : Tag() {
     override fun serialize(): String =
         super.serialize().let {
             if (Jsoup.isValid(it, Safelist.relaxed()))
-                UserWarning("Jsoup is telling me that the generated HTML is not 100% valid!")
+                logWarning("Jsoup is telling me that the generated HTML is not 100% valid!")
 
             Jsoup.parse(it).let {
                 builtDOMCache = it

--- a/src/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
@@ -3,6 +3,7 @@ package com.jdngray77.htmldesigner.frontend
 import com.jdngray77.htmldesigner.backend.EventNotifier
 import com.jdngray77.htmldesigner.backend.EventType
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvc
+import javafx.event.Event
 import javafx.fxml.FXML
 import javafx.scene.control.Tab
 import javafx.scene.web.WebView
@@ -118,6 +119,17 @@ class DocumentEditor {
     fun save() {
         mvc().Project.saveDocument(document)
         clean()
+    }
+
+    fun requestClose() {
+        val e = Event(javafx.event.EventType("INTERNAL_CLOSE_REQUEST"))
+        tab.onCloseRequest?.handle(e)
+
+        if (e.isConsumed) return
+
+        mvc().MainView.dockEditors.tabs.remove(tab)
+
+        tab.onClosed?.handle(e)
     }
 
     companion object {

--- a/src/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
@@ -2,6 +2,7 @@ package com.jdngray77.htmldesigner.frontend
 
 import com.jdngray77.htmldesigner.backend.EventNotifier
 import com.jdngray77.htmldesigner.backend.EventType
+import com.jdngray77.htmldesigner.backend.data.Project.Companion.projectFile
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvc
 import javafx.event.Event
 import javafx.fxml.FXML
@@ -9,6 +10,7 @@ import javafx.scene.control.Tab
 import javafx.scene.web.WebView
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import java.io.File
 
 /**
  * # Central document editor.
@@ -28,6 +30,12 @@ class DocumentEditor {
      * The document being edited.
      */
     lateinit var document : Document
+        private set
+
+    /**
+     * The document being edited.
+     */
+    lateinit var file : File
         private set
 
     /**
@@ -101,6 +109,7 @@ class DocumentEditor {
     fun setDocument(document: Document, tab: Tab) {
         if (this::document.isInitialized) return
 
+        this.file = document.projectFile()
         this.document = document
         this.tab = tab
 
@@ -127,9 +136,13 @@ class DocumentEditor {
 
         if (e.isConsumed) return
 
+        forceClose()
+    }
+
+    fun forceClose() {
         mvc().MainView.dockEditors.tabs.remove(tab)
 
-        tab.onClosed?.handle(e)
+        tab.onClosed?.handle(null)
     }
 
     companion object {

--- a/src/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
@@ -122,7 +122,7 @@ class DocumentEditor {
     }
 
     fun requestClose() {
-        val e = Event(javafx.event.EventType("INTERNAL_CLOSE_REQUEST"))
+        val e = Event(EDITOR_CLOSE_REQUEST)
         tab.onCloseRequest?.handle(e)
 
         if (e.isConsumed) return
@@ -138,5 +138,7 @@ class DocumentEditor {
          * A particle appended to the name when [isDirty]
          */
         private const val DIRTY_SUFFIX = " *"
+
+        private val EDITOR_CLOSE_REQUEST = javafx.event.EventType<Event>("EDITOR_CLOSE_REQUEST")
     }
 }

--- a/src/com/jdngray77/htmldesigner/frontend/Editor.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/Editor.kt
@@ -1,15 +1,12 @@
 package com.jdngray77.htmldesigner.frontend
 
-import com.jdngray77.htmldesigner.ExitReasons
 import com.jdngray77.htmldesigner.MVC
 import com.jdngray77.htmldesigner.backend.EventNotifier
 import com.jdngray77.htmldesigner.backend.EventType
-import com.jdngray77.htmldesigner.backend.WarnError
 import com.jdngray77.htmldesigner.backend.data.Project
 import com.jdngray77.htmldesigner.backend.loadFXMLScene
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.EDITOR
 import javafx.application.Application
-import javafx.application.Platform
 import javafx.scene.Scene
 import javafx.scene.control.Alert
 import javafx.scene.control.ButtonType
@@ -17,7 +14,6 @@ import javafx.stage.DirectoryChooser
 import javafx.stage.FileChooser
 import javafx.stage.Stage
 import java.io.File
-import kotlin.system.exitProcess
 
 
 /**
@@ -129,18 +125,22 @@ class Editor : Application() {
 
 
         var pathToLoad : String? = null
+        var projToLoad : Project? = null
 
         while (true) {
             try {
                 pathToLoad = userLoadProject()?.path
-            } catch (e: Exception) { }
+            } catch (_: Exception) { }
 
 
-            if (pathToLoad != null)
-                break;
+            if (pathToLoad == null) continue
+
+            projToLoad = Project.loadOrCreate(pathToLoad)
+
+            if (projToLoad != null) break
         }
 
-        mvc = MVC(Project.loadOrCreate(pathToLoad!!), scene.second)
+        mvc = MVC(projToLoad!!, scene.second)
     }
 
 

--- a/src/com/jdngray77/htmldesigner/frontend/Editor.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/Editor.kt
@@ -1,13 +1,23 @@
 package com.jdngray77.htmldesigner.frontend
 
+import com.jdngray77.htmldesigner.ExitReasons
 import com.jdngray77.htmldesigner.MVC
 import com.jdngray77.htmldesigner.backend.EventNotifier
 import com.jdngray77.htmldesigner.backend.EventType
+import com.jdngray77.htmldesigner.backend.WarnError
 import com.jdngray77.htmldesigner.backend.data.Project
 import com.jdngray77.htmldesigner.backend.loadFXMLScene
+import com.jdngray77.htmldesigner.frontend.Editor.Companion.EDITOR
 import javafx.application.Application
+import javafx.application.Platform
 import javafx.scene.Scene
+import javafx.scene.control.Alert
+import javafx.scene.control.ButtonType
+import javafx.stage.DirectoryChooser
+import javafx.stage.FileChooser
 import javafx.stage.Stage
+import java.io.File
+import kotlin.system.exitProcess
 
 
 /**
@@ -93,6 +103,8 @@ class Editor : Application() {
      */
     private lateinit var scene: Pair<Scene, MainViewController>
 
+    lateinit var stage: Stage
+
     /**
      * Loads and initalises the GUI.
      *
@@ -100,6 +112,8 @@ class Editor : Application() {
      * ocour until this method has returned.
      */
     override fun start(stage: Stage) {
+        this.stage = stage
+
         EDITOR = this
 
         // Load the main view from FXML.
@@ -112,6 +126,50 @@ class Editor : Application() {
 
         stage.scene = scene.first
         stage.show()
-        mvc = MVC(Project.loadOrCreate("./testproject/"), scene.second)
+
+
+        var pathToLoad : String? = null
+
+        while (true) {
+            try {
+                pathToLoad = userLoadProject()?.path
+            } catch (e: Exception) { }
+
+
+            if (pathToLoad != null)
+                break;
+        }
+
+        mvc = MVC(Project.loadOrCreate(pathToLoad!!), scene.second)
     }
+
+
+    private fun userLoadProject(): File? {
+
+        val ButtonTypeLoad = ButtonType("Load existing Project")
+        val ButtonTypeCreate = ButtonType("Create a new Project")
+
+        val x = Alert(Alert.AlertType.INFORMATION, "Welcome! What would you like to do?", ButtonTypeCreate, ButtonTypeLoad)
+        x.showAndWait()
+
+        return when (x.result) {
+            ButtonTypeLoad -> {
+                DirectoryChooser().let {
+                    it.title = "Locate a project root"
+                    it.showDialog(stage)
+                }
+            }
+
+            ButtonTypeCreate -> {
+                FileChooser().let {
+                    it.title = "Create a new project"
+                    it.showSaveDialog(stage)
+                }
+            }
+            else -> null
+        }
+
+
+    }
+
 }

--- a/src/com/jdngray77/htmldesigner/frontend/MainView.fxml
+++ b/src/com/jdngray77/htmldesigner/frontend/MainView.fxml
@@ -51,6 +51,7 @@
                   <Menu mnemonicParsing="false" text="IDE Debug">
                      <items>
                         <MenuItem mnemonicParsing="false" onAction="#menu_debug_err" text="Throw an exception" />
+                        <MenuItem mnemonicParsing="false" onAction="#menu_debug_showcache" text="Show Project File Cache" />
                         <MenuItem mnemonicParsing="false" onAction="#menu_debug_dirty" text="Mark current editor as dirty" />
                      </items>
                   </Menu>

--- a/src/com/jdngray77/htmldesigner/frontend/MainView.fxml
+++ b/src/com/jdngray77/htmldesigner/frontend/MainView.fxml
@@ -51,8 +51,13 @@
                   <Menu mnemonicParsing="false" text="IDE Debug">
                      <items>
                         <MenuItem mnemonicParsing="false" onAction="#menu_debug_err" text="Throw an exception" />
-                        <MenuItem mnemonicParsing="false" onAction="#menu_debug_showcache" text="Show Project File Cache" />
                         <MenuItem mnemonicParsing="false" onAction="#menu_debug_dirty" text="Mark current editor as dirty" />
+                        <Menu mnemonicParsing="false" text="Project">
+                           <items>
+                              <MenuItem mnemonicParsing="false" onAction="#menu_debug_showcache" text="Show Project File Cache Entires" />
+                              <MenuItem mnemonicParsing="false" onAction="#menu_debug_showserial" text="Show and Copy Project Serial Version" />
+                           </items>
+                        </Menu>
                      </items>
                   </Menu>
                   <MenuItem mnemonicParsing="false" text="Exit" />

--- a/src/com/jdngray77/htmldesigner/frontend/MainViewController.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/MainViewController.kt
@@ -1,14 +1,10 @@
 package com.jdngray77.htmldesigner.frontend
 
-import com.jdngray77.htmldesigner.backend.CamelToSentence
-import com.jdngray77.htmldesigner.backend.EventNotifier
-import com.jdngray77.htmldesigner.backend.EventType
+import com.jdngray77.htmldesigner.backend.*
 import com.jdngray77.htmldesigner.frontend.docks.TagHierarchy
 import com.jdngray77.htmldesigner.frontend.docks.Pages
 import com.jdngray77.htmldesigner.frontend.docks.ProjectDock
 import com.jdngray77.htmldesigner.frontend.docks.dockutils.TestDock
-import com.jdngray77.htmldesigner.backend.loadFXMLComponent
-import com.jdngray77.htmldesigner.backend.userConfirm
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvc
 import com.jdngray77.htmldesigner.frontend.docks.TagProperties
 import javafx.fxml.FXML
@@ -19,6 +15,7 @@ import javafx.scene.control.TabPane
 import javafx.scene.layout.BorderPane
 import javafx.scene.web.HTMLEditor
 import org.jsoup.nodes.Document
+import java.io.File
 
 
 /**
@@ -151,6 +148,16 @@ class MainViewController {
 
     fun menu_debug_dirty() {
         mvc().currentEditor().documentChanged()
+    }
+
+    fun menu_debug_showcache() {
+        AlertUser(
+            "Project files loaded into cache are : "
+            +
+            mvc().Project.getCache().entries.joinToString {
+                it.key + if (File(it.key).exists()) "" else "(Missing)" +"\n"
+            }
+        )
     }
 
     //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

--- a/src/com/jdngray77/htmldesigner/frontend/MainViewController.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/MainViewController.kt
@@ -1,18 +1,19 @@
 package com.jdngray77.htmldesigner.frontend
 
 import com.jdngray77.htmldesigner.backend.*
-import com.jdngray77.htmldesigner.frontend.docks.TagHierarchy
+import com.jdngray77.htmldesigner.backend.data.Project
+import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvc
 import com.jdngray77.htmldesigner.frontend.docks.Pages
 import com.jdngray77.htmldesigner.frontend.docks.ProjectDock
-import com.jdngray77.htmldesigner.frontend.docks.dockutils.TestDock
-import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvc
+import com.jdngray77.htmldesigner.frontend.docks.TagHierarchy
 import com.jdngray77.htmldesigner.frontend.docks.TagProperties
+import com.jdngray77.htmldesigner.frontend.docks.dockutils.TestDock
 import javafx.fxml.FXML
-import javafx.scene.control.ButtonType
 import javafx.scene.control.Label
 import javafx.scene.control.Tab
 import javafx.scene.control.TabPane
-import javafx.scene.layout.BorderPane
+import javafx.scene.input.Clipboard
+import javafx.scene.input.ClipboardContent
 import javafx.scene.web.HTMLEditor
 import org.jsoup.nodes.Document
 import java.io.File
@@ -159,6 +160,13 @@ class MainViewController {
             }
         )
     }
+
+    fun menu_debug_showserial() {
+        val serial = Project::class.hashCode()
+        CopyToClipboard(serial.toString())
+        AlertUser("The current project serial hash version is : \n $serial")
+    }
+
 
     //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     //endregion                                                 Menu

--- a/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
@@ -62,10 +62,7 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
             MenuItem("Delete").also {
                 it.setOnAction {
                     contextItem?.let { it1 -> mvc().delete(it1) }
-                    // TODO deletion logic shouldn't be here.
-                    // FIXME this does not clear the document from the editor or
-                    //       project cache.
-
+                    refresh()
                 }
             },
             MenuItem("「TODO」Cut"),

--- a/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
@@ -20,7 +20,7 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
             implOpenSelected()
         }
 
-        tree.setOnKeyTyped {
+        tree.setOnKeyPressed {
             if (it.code == KeyCode.ENTER)
                 implOpenSelected()
         }

--- a/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
@@ -115,9 +115,9 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
             createDocument(
                 (contextOrSelectedOrNull()?.let {
                     if (it.isDirectory)
-                        it.relativeTo(HTML).path + "/"
+                        it.relativeTo(HTML).path  + "/"
                     else
-                        it.relativeTo(HTML).parentFile.path
+                        it.relativeTo(HTML).parentFile?.let{ it.path + "/" } ?: ""
                 } ?: "")
                         +
                         TextInputDialog("FancyPage.html").let{

--- a/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
@@ -1,12 +1,11 @@
 package com.jdngray77.htmldesigner.frontend.docks
 
 import com.jdngray77.htmldesigner.backend.*
-import com.jdngray77.htmldesigner.frontend.Editor
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvc
 import com.jdngray77.htmldesigner.frontend.docks.dockutils.HierarchyDock
 import javafx.beans.property.SimpleObjectProperty
-import javafx.scene.control.TreeTableColumn
-import org.jsoup.nodes.Element
+import javafx.scene.control.*
+import javafx.scene.input.KeyCode
 import java.io.File
 import java.sql.Time
 import java.time.Instant
@@ -18,15 +17,14 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
         EventNotifier.subscribe(this, EventType.PROJECT_PAGE_DELETED, EventType.PROJECT_PAGE_CREATED)
 
         tree.setOnMouseClicked {
-            tree.selectionModel.selectedItem?.apply {
-                    (this as StoringTreeItem<File>).data!!.apply{
-                        if (this.isDirectory)
-                            return@setOnMouseClicked
-
-                        mvc().openDocument(this)
-                }
-            }
+            implOpenSelected()
         }
+
+        tree.setOnKeyTyped {
+            if (it.code == KeyCode.ENTER)
+                implOpenSelected()
+        }
+
 
         tree.columns.setAll(
             TreeTableColumn<File, String>("Name").also {
@@ -41,12 +39,52 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
                 }
             }
         )
+
+        // TODO these are not cancelable
+
+
+        setContextMenu(
+            MenuItem("New Page").also {
+                it.setOnAction {
+                    implCreateNewPage()
+                }
+            },
+
+
+            MenuItem("New Folder").also {
+                it.setOnAction {
+                    implCreateNewFolder()
+                }
+            },
+
+
+            SeparatorMenuItem(),
+            MenuItem("Delete").also {
+                it.setOnAction {
+                    contextItem?.let { it1 -> mvc().delete(it1) }
+                    // TODO deletion logic shouldn't be here.
+                    // FIXME this does not clear the document from the editor or
+                    //       project cache.
+
+                }
+            },
+            MenuItem("「TODO」Cut"),
+            MenuItem("「TODO」Copy"),
+            SeparatorMenuItem(),
+            MenuItem("「TODO」Paste clipboard as above"),
+            MenuItem("「TODO」Paste clipboard as below"),
+            SeparatorMenuItem(),
+            MenuItem("「TODO」New folder with selected items"),
+        )
+
+
     }
 
     override fun notify(e: EventType) {
         refresh()
     }
 
+    // FIXME everything is expanded on refresh.
     fun refresh() {
         mvc().Project.HTML.apply {
             setRoot(this)
@@ -55,4 +93,54 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
     }
 
     override fun getChildrenFor(el: File) = el.listFiles()?.toList() ?: arrayListOf()
+
+    private fun implCreateNewFolder() {
+        mvc().Project.apply {
+            File(
+                (contextOrSelectedOrNull()?.let {
+                    if (it.isDirectory)
+                        it.path + "/"
+                    else
+                        it.parentFile.path
+                } ?: "HTML")
+                + "/" + TextInputDialog("FancyProject").let{
+                it.showAndWait()
+                it.result
+            }).mkdirs()
+            refresh()
+        }
+    }
+
+    private fun contextOrSelectedOrNull() = contextItem ?: selectedItems().getOrNull(0)
+
+    private fun implCreateNewPage() {
+        mvc().Project.apply {
+            createDocument(
+                (contextOrSelectedOrNull()?.let {
+                    if (it.isDirectory)
+                        it.relativeTo(HTML).path + "/"
+                    else
+                        it.relativeTo(HTML).parentFile.path
+                } ?: "")
+                        +
+                        TextInputDialog("FancyPage.html").let{
+                            it.showAndWait()
+                            it.result.AssertEndsWith(".html")
+                        }
+            ).open()
+            refresh()
+        }
+    }
+
+    private fun implOpenSelected() {
+        tree.selectionModel.selectedItem?.apply {
+            (this as StoringTreeItem<File>).data!!.apply{
+                if (this.isDirectory)
+                    return
+
+                mvc().openDocument(this)
+            }
+        }
+    }
+
 }

--- a/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/Pages.kt
@@ -102,7 +102,10 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
                 } ?: "HTML")
                 + "/" + TextInputDialog("FancyProject").let{
                 it.showAndWait()
-                it.result
+                if (it.result.isNullOrBlank())
+                    return
+                else
+                    it.result
             }).mkdirs()
             refresh()
         }
@@ -122,7 +125,10 @@ class Pages : HierarchyDock<File>({it!!.name}), Subscriber {
                         +
                         TextInputDialog("FancyPage.html").let{
                             it.showAndWait()
-                            it.result.AssertEndsWith(".html")
+                            if (it.result.isNullOrBlank())
+                                return
+                            else
+                                it.result.AssertEndsWith(".html")
                         }
             ).open()
             refresh()

--- a/src/com/jdngray77/htmldesigner/frontend/docks/TagHierarchy.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/TagHierarchy.kt
@@ -73,7 +73,7 @@ class TagHierarchy : HierarchyDock<Element>({it!!.tagName()}), Subscriber {
         // When a new item is selected, display it in the editor.
 
         tree.setOnMouseClicked {
-            selectedTags().apply {
+            selectedItems().apply {
                 mvc().let {
                     it.MainView.textEditor_Open(
                         if (size != 1) {
@@ -92,39 +92,31 @@ class TagHierarchy : HierarchyDock<Element>({it!!.tagName()}), Subscriber {
 
         // Context menu
         // TODO only show some of these items when one item is selected.
-        val ctx = ContextMenu()
-        ctx.items.addAll(
-                MenuItem("「TODO」Edit alone"),
-                SeparatorMenuItem(),
-                MenuItem("Delete"),
-                MenuItem("「TODO」Cut"),
-                MenuItem("「TODO」Copy"),
-                SeparatorMenuItem(),
-                MenuItem("「TODO」Paste clipboard as above"),
-                MenuItem("「TODO」Paste clipboard as child"),
-                MenuItem("「TODO」Paste clipboard as below"),
-                MenuItem("「TODO」Wrap with clipboard"),
-                SeparatorMenuItem(),
-                MenuItem("「TODO」Move up"),
-                MenuItem("「TODO」Move down"),
-                SeparatorMenuItem(),
-                MenuItem("「TODO」Delete...")
-        )
-
-        tree.setRowFactory {
-            TreeTableRow<Element?>().apply {
-                contextMenu = ctx
-                setOnContextMenuRequested {
-                    ctx.items[2].setOnAction {
-                        selectedTags().apply {
-                            if (size > 1)
-                                mvc().deleteTag(*toTypedArray())
-                            else item?.let { mvc().deleteTag(it) }
-                        }
+        setContextMenu(
+            MenuItem("「TODO」Edit alone"),
+            SeparatorMenuItem(),
+            MenuItem("Delete").also {
+                it.setOnAction {
+                    selectedItems().apply {
+                        if (size > 1)
+                            mvc().deleteTag(*toTypedArray())
+                        else contextRow?.let { mvc().deleteTag(it.item) }
                     }
                 }
-            }
-        }
+            },
+            MenuItem("「TODO」Cut"),
+            MenuItem("「TODO」Copy"),
+            SeparatorMenuItem(),
+            MenuItem("「TODO」Paste clipboard as above"),
+            MenuItem("「TODO」Paste clipboard as child"),
+            MenuItem("「TODO」Paste clipboard as below"),
+            MenuItem("「TODO」Wrap with clipboard"),
+            SeparatorMenuItem(),
+            MenuItem("「TODO」Move up"),
+            MenuItem("「TODO」Move down"),
+            SeparatorMenuItem(),
+            MenuItem("「TODO」Delete...")
+        )
 
 
         tree.pack()
@@ -148,14 +140,7 @@ class TagHierarchy : HierarchyDock<Element>({it!!.tagName()}), Subscriber {
             showDocument(mvc().currentDocument())
     }
 
-    /**
-     * If an element **inside** the root is selected within the [tree], it is returned.
-     */
-    fun selectedTags() =
-        tree.selectionModel.selectedItems
-            .filterNot { it == tree.root }
-            .map { (it as StoringTreeItem<Element>).data }
-            .filterNotNull()
+
 
     override fun getChildrenFor(el: Element): Iterable<Element> = el.children()
 

--- a/src/com/jdngray77/htmldesigner/frontend/docks/dockutils/AutoDock.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/dockutils/AutoDock.kt
@@ -8,7 +8,7 @@ import javafx.scene.control.Spinner
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
 import kotlin.reflect.full.memberProperties
-import com.jdngray77.htmldesigner.backend.DeveloperWarning
+import com.jdngray77.htmldesigner.backend.logWarning
 import com.jdngray77.htmldesigner.backend.changeProperty
 import javafx.scene.Parent
 import javafx.scene.control.Button
@@ -22,7 +22,6 @@ import javafx.scene.web.WebView
 import javafx.scene.control.Pagination
 import javafx.scene.control.ComboBox
 import javafx.scene.layout.GridPane
-import org.controlsfx.control.PropertySheet
 import org.jsoup.nodes.Document
 import java.time.Instant
 import java.time.ZoneId
@@ -255,7 +254,7 @@ open class AutoDock : Dock() {
                 throw InspectableException("${loggableClassName()} $guiname has the wrong type ($returnType). It needs to be ${gui::class.qualifiedName} for the ${prop.returnType} stored in ${prop.name}")
             }
         } ?: run {
-            DeveloperWarning("${loggableClassName()} ${prop.name} does not have a matching $guiname variable for it's UI control.")
+            logWarning("${loggableClassName()} ${prop.name} does not have a matching $guiname variable for it's UI control.")
         }
     }
 

--- a/src/com/jdngray77/htmldesigner/frontend/docks/dockutils/ExampleAutoDock.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/dockutils/ExampleAutoDock.kt
@@ -1,6 +1,6 @@
 package com.jdngray77.htmldesigner.frontend.docks.dockutils
 
-import com.jdngray77.htmldesigner.backend.UserWarning
+import com.jdngray77.htmldesigner.backend.logWarning
 import java.time.Instant
 import java.util.*
 
@@ -37,7 +37,7 @@ class ExampleAutoDock() : AutoDock() {
 
     // Note the position number here. Even though it's at the bottom of the file, it gets placed into the first group of controls.
     @Inspectable(20)
-    fun HelloWorld() = UserWarning("Fuck you.")
+    fun HelloWorld() = logWarning("Fuck you.")
 
 
     // Remember to call create when ready to populate the GUI.

--- a/src/com/jdngray77/htmldesigner/frontend/docks/dockutils/HierarchyDock.kt
+++ b/src/com/jdngray77/htmldesigner/frontend/docks/dockutils/HierarchyDock.kt
@@ -3,8 +3,12 @@ package com.jdngray77.htmldesigner.frontend.docks.dockutils
 import com.jdngray77.htmldesigner.backend.StoringTreeItem
 import com.jdngray77.htmldesigner.backend.EventType
 import com.jdngray77.htmldesigner.backend.pack
+import javafx.scene.control.ContextMenu
+import javafx.scene.control.MenuItem
+import javafx.scene.control.TreeTableRow
 import javafx.scene.control.TreeTableView
 import javafx.scene.layout.HBox
+import org.jsoup.nodes.Element
 
 /**
  * A dock which can display the hierarchy of anything.
@@ -41,6 +45,39 @@ abstract class HierarchyDock <T> (val titler: (T?) -> String) : Dock() {
         tree.pack()
     }
 
+
+    /**
+     * Stores the context of the row that was right-clicked.
+     *
+     * Used by items in the context-menu
+     */
+    protected var contextRow : TreeTableRow<T>? = null
+        set(value) {
+            field = value
+            contextItem = field?.item
+        }
+
+    /**
+     * Quick access to the item stored by the row that
+     * was right clicked.
+     */
+    protected var contextItem : T? = null
+
+    /**
+     *
+     */
+    protected fun setContextMenu(vararg items : MenuItem) {
+        tree.contextMenu = ContextMenu(*items)
+
+        tree.setRowFactory {
+            TreeTableRow<T>().apply {
+                setOnContextMenuRequested {
+                    contextRow = this
+                }
+            }
+        }
+    }
+
     /**
      * Recursively constructs tree items from a tree of elements.
      */
@@ -57,6 +94,14 @@ abstract class HierarchyDock <T> (val titler: (T?) -> String) : Dock() {
         }
         return parent
     }
+
+    /**
+     * If an element **inside** the root is selected within the [tree], it is returned.
+     */
+    protected fun selectedItems() =
+        tree.selectionModel.selectedItems
+            .filterNot { it == tree.root }
+            .mapNotNull { (it as StoringTreeItem<T>).data }
 
     /**
      * Provides the children for an element.


### PR DESCRIPTION
Upon boot, you can load or create a project, instead of being forced to use the test project.

Adds a bunch of validation for files, project caches, and open editors.

Pages & directories can be created and deleted from the pages dock by right-clicking.

**Known issues**
As described by #15 , the load and create on boot can be funky.
Loading a project may actually lead to creation of a project or a crash, depending on what directory you choose.

@Dylan773 If you could just give this stuff a test by creating and deleting a bunch of files and folders and seeing if you can get it to break.

**Remaining Tasks **
 - [ ] Fix #15 
 - [ ] Refactor code in Project.kt, Editor.kt, MVC.kt and Pages.kt