### PR TITLE
Stand alone edit mode.

### DIFF
--- a/src/main/kotlin/com/jdngray77/htmldesigner/backend/data/config/Config.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/backend/data/config/Config.kt
@@ -29,7 +29,8 @@ enum class Configs {
     TOOLBOX_DOCK_FILTER_EXACT_BOOL,
     USE_MAC_MENU_BOOL,
 
-    OUTLINE_SELECTED_TAG_BOOL
+    OUTLINE_SELECTED_TAG_BOOL,
+    AUTO_LOAD_PROJECT_BOOL
 }
 
 /**
@@ -53,6 +54,7 @@ object Config : Registry<Configs>(File("./HTMLDesignerCfg.registry")) {
         put(Configs.TOOLBOX_DOCK_FILTER_EXACT_BOOL, true)
         put(Configs.USE_MAC_MENU_BOOL, true)
         put(Configs.OUTLINE_SELECTED_TAG_BOOL, true)
+        put(Configs.AUTO_LOAD_PROJECT_BOOL, true)
     }
 
     override fun validate() {

--- a/src/main/kotlin/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
@@ -15,25 +15,27 @@
 
 package com.jdngray77.htmldesigner.frontend
 
-import com.jdngray77.htmldesigner.backend.EventNotifier
-import com.jdngray77.htmldesigner.backend.EventType
+import com.jdngray77.htmldesigner.backend.*
 import com.jdngray77.htmldesigner.backend.data.Project.Companion.projectFile
 import com.jdngray77.htmldesigner.backend.data.config.Config
 import com.jdngray77.htmldesigner.backend.data.config.Configs
 import com.jdngray77.htmldesigner.backend.data.config.ProjectPreference
-import com.jdngray77.htmldesigner.backend.userConfirm
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.mvc
 import com.jdngray77.htmldesigner.frontend.Editor.Companion.project
 import com.jdngray77.htmldesigner.utility.ButtonType_CLOSEWITHOUTSAVE
 import com.jdngray77.htmldesigner.utility.ButtonType_SAVE
-import impl.org.controlsfx.skin.BreadCrumbBarSkin
+import com.jdngray77.htmldesigner.utility.toHex
+import com.sun.javafx.scene.control.skin.Utils
 import javafx.application.Platform
 import javafx.event.Event
 import javafx.fxml.FXML
 import javafx.scene.control.*
 import javafx.scene.layout.BorderPane
+import javafx.scene.layout.HBox
+import javafx.scene.paint.Color
 import javafx.scene.web.WebView
 import org.controlsfx.control.BreadCrumbBar
+import org.controlsfx.control.ToggleSwitch
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.io.File
@@ -60,7 +62,7 @@ import kotlin.math.roundToInt
  */
 class DocumentEditor {
 
-    //region initalization
+    //region initialization
 
     /**
      * Late 'init' called by FXML.
@@ -149,7 +151,7 @@ class DocumentEditor {
     }
 
 
-    //#region initalization
+    //#endregion initalization
 
 
     /**
@@ -234,6 +236,9 @@ class DocumentEditor {
             // Guard against excluding head
             if (value == document.body()) return
 
+            if (value == null)
+                standaloneEditMode = false
+
             field?.removeClass("debug-outline")
             field = value
 
@@ -243,6 +248,93 @@ class DocumentEditor {
             reRender()
             EventNotifier.notifyEvent(EventType.EDITOR_SELECTED_TAG_CHANGED)
         }
+
+
+
+
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    //#region standalone edit mode
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+
+
+    /**
+     * Determines the background color of the editor
+     * when in standalone edit mode.
+     */
+    private val standaloneColorPicker = ColorPicker().also {
+        it.value = Color.web("#808080")
+        it.setOnAction {
+            reRender()
+        }
+    }
+
+    /**
+     * A toggle switch that determines if the content is center aligned when in standalone edit mode.
+     */
+    private val standaloneCenter = ToggleSwitch("Align to center").also {
+            it.setOnMouseClicked {
+                reRender()
+            }
+        }
+
+    /**
+     * A notification pane shown when the editor is in standalone edit mode.
+     *
+     * Contains controls to exit standalone edit mode, background color and toggle center alignment.
+     */
+    private val standaloneNotificationPane = NotificationPane("You're in standalone edit mode. Only the selected tag will be rendered.", "Exit standalone edit mode") {standaloneEditMode = false}.apply {
+        (content as BorderPane).apply {
+            val vbox = HBox(
+                right,
+                standaloneColorPicker,
+                standaloneCenter
+            ).apply {
+                spacing = 20.0
+            }
+            right = vbox
+        }
+    }
+
+
+    /**
+     * Standalone editor mode.
+     *
+     * When true, [selectedTag] becomes the only content to be rendered.
+     *
+     * if [Configs.STANDALONE_MODE_ALIGN_CENTER_BOOL] is true, the content will be
+     * rendered in the center of the editor.
+     *
+     * Cannot be enabled while [selectedTag] is null, and
+     * clearing selectedTab will clear this flag.
+     */
+    var standaloneEditMode: Boolean = false
+        set(value) {
+            if (selectedTag == null)
+                return
+
+            field = value
+
+
+            editorRoot.top =
+                if (field)
+                    standaloneNotificationPane
+                else
+                    null
+
+
+
+            reRender()
+        }
+
+
+
+
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    //#endregion standalone edit mode
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+
+
+
 
     /**
      * Selects the given element, but does not populate the [breadCrumb].
@@ -264,8 +356,9 @@ class DocumentEditor {
         breadCrumb.selectedCrumb = treeItem
     }
 
-
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     //region dirty
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
     /**
      * When raised, this flag indicates that this editor has been changed.
@@ -299,14 +392,30 @@ class DocumentEditor {
         isDirty = false
     }
 
-
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     //endregion Dirty
-
+    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
     /**
      * Updates [WebView] to display the current state of the [document]
      */
-    fun reRender() = contentRenderer.engine.loadContent(document.toString())
+    fun reRender() {
+        contentRenderer.engine.loadContent(
+            if (standaloneEditMode)
+                Element("div")
+                    .attr("style",
+                        "background: ${standaloneColorPicker.value.toHex()}; height: 100%; width: 100%; ${
+                            if (standaloneCenter.isSelected) 
+                                    "display: flex; " +
+                                    "justify-content: center; " +
+                                    "align-items: center; "
+                            else ""}")
+                    .appendChild(selectedTag!!.clone()).outerHtml()
+            else
+                document.toString()
+
+        )
+    }
 
     /**
      * Saves the document this editor is for.
@@ -444,11 +553,4 @@ class DocumentEditor {
          */
         private val EDITOR_CLOSE_REQUEST = javafx.event.EventType<Event>("EDITOR_CLOSE_REQUEST")
     }
-
-
-    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-    //region                                   GUI
-    //░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-
-
 }

--- a/src/main/kotlin/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/frontend/DocumentEditor.kt
@@ -272,6 +272,7 @@ class DocumentEditor {
      * A toggle switch that determines if the content is center aligned when in standalone edit mode.
      */
     private val standaloneCenter = ToggleSwitch("Align to center").also {
+            it.isSelected = true
             it.setOnMouseClicked {
                 reRender()
             }

--- a/src/main/kotlin/com/jdngray77/htmldesigner/frontend/Editor.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/frontend/Editor.kt
@@ -204,7 +204,7 @@ class Editor : Application() {
     }
 
     private fun determineProject(): Project =
-        if (Config[Configs.LAST_PROJECT_PATH_STRING] == "")
+        if (!(Config[Configs.AUTO_LOAD_PROJECT_BOOL] as Boolean) || Config[Configs.LAST_PROJECT_PATH_STRING] == "")
             usrChooseProject().also {
                 Config.put(Configs.LAST_PROJECT_PATH_STRING, it.locationOnDisk.path)
             }

--- a/src/main/kotlin/com/jdngray77/htmldesigner/frontend/docks/TagHierarchy.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/frontend/docks/TagHierarchy.kt
@@ -124,7 +124,14 @@ class TagHierarchy : HierarchyDock<Element>({it!!.tagName()}), Subscriber {
 
         setContextMenu(
             // TODO
-            MenuItem("「INOP」Edit alone"),
+            MenuItem("Edit alone").also {
+                it.setOnAction {
+                    mvc().currentEditor().apply {
+                        selectTag(selectedTableItems().first())
+                        standaloneEditMode = true
+                    }
+                }
+            },
             MenuItem("「WIP」Save As Prefab").also {
                 it.setOnAction {
                     selectedItems().map {

--- a/src/main/kotlin/com/jdngray77/htmldesigner/utility/FXMLGUI.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/utility/FXMLGUI.kt
@@ -37,9 +37,12 @@ import javafx.fxml.FXMLLoader
 import javafx.scene.Parent
 import javafx.scene.Scene
 import javafx.scene.control.ButtonType
+import javafx.scene.paint.Color
 import jfxtras.styles.jmetro.JMetro
 import jfxtras.styles.jmetro.Style
 import java.awt.Toolkit
+import java.util.*
+import kotlin.math.roundToInt
 
 /**
  * Loads a FXML file as a scene, and initalises it's controllers and stylesheets.
@@ -114,3 +117,11 @@ fun getTheme() = JMetro(
 val ButtonType_SAVE: ButtonType = ButtonType("Save")
 
 val ButtonType_CLOSEWITHOUTSAVE: ButtonType = ButtonType("Don't save")
+
+fun Color.toHex(): String {
+    return String.format(null, "#%02x%02x%02x",
+            (red * 255).roundToInt(),
+            (green * 255).roundToInt(),
+            (blue * 255).roundToInt()
+        )
+}

--- a/src/main/kotlin/com/jdngray77/htmldesigner/utility/Logging.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/utility/Logging.kt
@@ -19,11 +19,19 @@ import com.jdngray77.htmldesigner.backend.data.config.Config
 import com.jdngray77.htmldesigner.backend.data.config.Configs
 import com.jdngray77.htmldesigner.frontend.Editor
 import javafx.application.Platform
+import javafx.geometry.Insets
+import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.control.Alert
+import javafx.scene.control.Button
 import javafx.scene.control.ButtonType
+import javafx.scene.control.Label
 import javafx.scene.control.TextInputDialog
+import javafx.scene.layout.*
+import javafx.scene.paint.Color
+import javafx.scene.paint.Paint
 import javafx.scene.text.Text
+import org.controlsfx.control.NotificationPane
 import org.controlsfx.control.Notifications
 import org.controlsfx.control.PopOver
 import java.io.PrintWriter
@@ -81,6 +89,31 @@ fun showNotification(title: String = "", message: String = "") {
             .showInformation()
     }
 }
+
+/**
+ * A utility to create a notification pane.
+ *
+ * It is not shown, so take the return value and place it within the GUI.
+ */
+fun NotificationPane(string: String, buttonText: String = "", showOnBottom: Boolean = false, runnable: Runnable? = null) =
+        NotificationPane(
+            BorderPane().also {
+
+                it.left = HBox(Label(string)).also { it.alignment = Pos.CENTER }
+                if (runnable != null)
+                    it.right = Button(buttonText).also {
+                        it.setOnAction {
+                            runnable.run()
+                        }
+                    }
+            }
+        ).apply {
+            padding = Insets(10.0)
+            prefHeight = 48.0
+            isShowFromTop = !showOnBottom
+            show()
+        }
+
 
 // TODO most of these functions need to be on the UI thread.
 


### PR DESCRIPTION
> Note to self : Merge #31 first!

Adds the ability to isolate a single html element and it's children within the editor.

closes #42 

On top of #42 's requirements, this also adds the ability to change the background colour for configurable contrast.

Since the standalone mode shows the selected tag, you can change which tag is shown by just selecting a new tag.


https://user-images.githubusercontent.com/50697488/180324750-c101832a-8f1a-42b7-b14b-a7bf10fc569f.mov


