### PR TITLE
Dev/56 - Run the shutdown routine when the window is closed.

### DIFF
--- a/src/main/kotlin/com/jdngray77/htmldesigner/frontend/Editor.kt
+++ b/src/main/kotlin/com/jdngray77/htmldesigner/frontend/Editor.kt
@@ -178,6 +178,16 @@ class Editor : Application() {
                 exitProcess(ExitCodes.ERROR_NO_MVC.ordinal)
             }
         }
+
+        stage.setOnCloseRequest {
+            try {
+                stop()
+            } catch (e: Exception) {
+                // Shutdown routine failed or rejected.
+                // Cancel close request.
+                it.consume()
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
closes #6
closes #25

When the main window is requested to close, regardless of how (including Alt-f4/cmd-q and `x` button.), capture the event and trigger the shutdown routine.

The request is rejected if the routine fails to complete (i.e user cancels in order to save)

Running the routine shuts down the web server, closes #56